### PR TITLE
fix: generate sso auth url with workos connection

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/service/SsoLoginSevice.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/SsoLoginSevice.kt
@@ -6,7 +6,8 @@ import com.hypto.iam.server.models.AuthUrlResponse
 import com.hypto.iam.server.models.SsoLoginRequest
 import com.hypto.iam.server.security.AuthenticationException
 import com.workos.WorkOS
-import com.workos.organizations.OrganizationsApi
+import com.workos.sso.SsoApi
+import com.workos.sso.models.ConnectionState
 import io.ktor.server.plugins.BadRequestException
 import mu.KotlinLogging
 import org.koin.core.component.KoinComponent
@@ -32,20 +33,19 @@ class SsoLoginServiceImpl : SsoLoginService, KoinComponent {
         ssoLoginRequest: SsoLoginRequest,
     ): AuthUrlResponse {
         return try {
-            val domains = listOf(ssoLoginRequest.domain)
-            val options = OrganizationsApi.ListOrganizationsOptions.builder().domains(domains).build()
-            val organizations = workos.organizations.listOrganizations(options)
-            if (organizations.data.isEmpty()) {
+            val connectionOptions = SsoApi.ListConnectionsOptions.builder().domain(ssoLoginRequest.domain).build()
+            val connections = workos.sso.listConnections(connectionOptions)
+            if (connections.data.isEmpty() || connections.data[0].state != ConnectionState.Active) {
                 throw WorkOSBadRequestException("SSO not configured for ${ssoLoginRequest.domain}. Please contact administrator.", null, null, UUID.randomUUID().toString())
             }
-            val url = workos.sso.getAuthorizationUrl(appConfig.workOS.clientId, ssoLoginRequest.redirectUri).organization(organizations.data[0].id).state(WORKOS_STATE).build()
+            val url = workos.sso.getAuthorizationUrl(appConfig.workOS.clientId, ssoLoginRequest.redirectUri).connection(connections.data[0].id).state(WORKOS_STATE).build()
             AuthUrlResponse(url)
         } catch (e: WorkOSUnauthorizedException) {
             logger.error { "Unauthorized - ${e.message}" }
             throw AuthenticationException(e.message ?: "Unauthorized")
         } catch (e: WorkOSBadRequestException) {
             logger.error { "Bad request - ${e.message}" }
-            throw BadRequestException("Error while getting authentication URL from WorkOS")
+            throw BadRequestException(e.message ?: "Error while getting authentication URL from WorkOS")
         } catch (e: WorkOSNotFoundException) {
             logger.error { "$ENTITY_NOT_FOUND - ${e.message}" }
             throw EntityNotFoundException(ENTITY_NOT_FOUND)


### PR DESCRIPTION
problem:
workos organization can exist without an active connection

solution:
get connection with respect to domain and check connection's state. 
generate auth url using connectionId
send more meaningful error message response in case of failure.