### PR TITLE
fix:  new user creation for new org when user exists in sub-org of different org

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
+++ b/src/main/kotlin/com/hypto/iam/server/db/repositories/UserRepo.kt
@@ -77,13 +77,16 @@ object UserRepo : BaseRepo<UsersRecord, Users, String>() {
         builder =
             if (uniqueCheck) {
                 // Check only verified users in other organizations and all users within the organization
-                builder.and(
-                    (
-                        USERS.VERIFIED.eq(true)
-                            .andNot(USERS.ORGANIZATION_ID.eq(organizationId))
-                    )
-                        .or(USERS.ORGANIZATION_ID.eq(organizationId)),
-                )
+                if (subOrganizationName == null) {
+                    builder
+                        .and(
+                            USERS.VERIFIED.eq(true)
+                                .or(USERS.ORGANIZATION_ID.eq(organizationId)),
+                        )
+                        .and(USERS.SUB_ORGANIZATION_NAME.isNull)
+                } else {
+                    builder.and(USERS.SUB_ORGANIZATION_NAME.eq(subOrganizationName).and(USERS.ORGANIZATION_ID.eq(organizationId)))
+                }
             } else {
                 // Check all verified and unverified users within the organization
                 builder.and(USERS.ORGANIZATION_ID.eq(organizationId))


### PR DESCRIPTION


problem:
A new user cannot for a new organization when the user already exists as a sub organization in a different organization

solution:
add if-else check based on sub-org-name
if sub-org-name is null, append sub-org-name null check else add sub-org-name and org-id check