### PR TITLE
fix: handle invalid WorkOS access token for SSO flow

### DIFF
--- a/src/main/kotlin/com/hypto/iam/server/authProviders/WorkOSAuthProvider.kt
+++ b/src/main/kotlin/com/hypto/iam/server/authProviders/WorkOSAuthProvider.kt
@@ -12,6 +12,7 @@ import mu.KotlinLogging
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.UUID
+import com.workos.common.exceptions.BadRequestException as WorkOSBadRequestException
 import com.workos.common.exceptions.NotFoundException as WorkOSNotFoundException
 import com.workos.common.exceptions.UnauthorizedException as WorkOSUnauthorizedException
 
@@ -37,12 +38,15 @@ object WorkOSAuthProvider : BaseAuthProvider("workos"), KoinComponent {
                 this.providerName,
                 AuthMetadata(profileAndToken.profile.id),
             )
+        } catch (e: WorkOSBadRequestException) {
+            logger.error { "Bad Request - ${e.message}" }
+            throw AuthenticationException(e.message ?: "Invalid access token")
         } catch (e: WorkOSUnauthorizedException) {
             logger.error { "Unauthorized - ${e.message}" }
             throw AuthenticationException(e.message ?: "Unauthorized")
         } catch (e: WorkOSNotFoundException) {
             logger.error { "Profile not found - ${e.message}" }
-            throw EntityNotFoundException("Profile not found")
+            throw EntityNotFoundException(e.message ?: "Profile not found")
         }
     }
 }


### PR DESCRIPTION
Description:
- Redirect to login URL if the user has already signed up and clicks SSO signup.
- Redirect to signup URL if the user tries to log in via SSO without prior signup.

Problem:
- Currently, the API throws a 500 error for invalid access tokens.
- WorkOS tokens can only be used once, and the frontend relies on specific error messages from the API.

Solution:
- Workos throws a Bad Request exception for invalid access tokens.
- Capture this exception and throw an Authentication exception with the message "Invalid access token."