### PR TITLE
feat: add email as login hint in workos auth url param

### DIFF
--- a/iam_openapi_spec.yml
+++ b/iam_openapi_spec.yml
@@ -3521,6 +3521,7 @@ components:
       value:
         domain: email.com
         redirectUri: https://staging-dashboard.togai.dev/login
+        email: email@example.com
 
   schemas:
     # Requests
@@ -4677,12 +4678,16 @@ components:
       required:
         - domain
         - redirectUri
+        - email
       properties:
         domain:
           description: Domain of the user's organization
           type: string
         redirectUri:
           description: callback url for generating authentication url
+          type: string
+        email:
+          description: email of the user
           type: string
 
 externalDocs:

--- a/src/main/kotlin/com/hypto/iam/server/service/SsoLoginSevice.kt
+++ b/src/main/kotlin/com/hypto/iam/server/service/SsoLoginSevice.kt
@@ -38,7 +38,13 @@ class SsoLoginServiceImpl : SsoLoginService, KoinComponent {
             if (connections.data.isEmpty() || connections.data[0].state != ConnectionState.Active) {
                 throw WorkOSBadRequestException("SSO not configured for ${ssoLoginRequest.domain}. Please contact administrator.", null, null, UUID.randomUUID().toString())
             }
-            val url = workos.sso.getAuthorizationUrl(appConfig.workOS.clientId, ssoLoginRequest.redirectUri).connection(connections.data[0].id).state(WORKOS_STATE).build()
+            val url =
+                workos.sso
+                    .getAuthorizationUrl(appConfig.workOS.clientId, ssoLoginRequest.redirectUri)
+                    .connection(connections.data[0].id)
+                    .state(WORKOS_STATE)
+                    .loginHint(ssoLoginRequest.email)
+                    .build()
             AuthUrlResponse(url)
         } catch (e: WorkOSUnauthorizedException) {
             logger.error { "Unauthorized - ${e.message}" }

--- a/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
+++ b/src/main/kotlin/com/hypto/iam/server/validators/RequestModelValidator.kt
@@ -633,6 +633,9 @@ val ssoLoginRequest =
     Validation {
         SsoLoginRequest::domain required {}
         SsoLoginRequest::redirectUri required {}
+        SsoLoginRequest::email required {
+            run(emailCheck)
+        }
     }
 
 @Suppress("MagicNumber")


### PR DESCRIPTION
problem
avoid entering user email twice(in togai & idP)

solution
pass user email as login hint param to generate auth url workos will prefill the email, if that idP supports prefill.

idP supporting prefil today:  OAuth, OpenID Connect, Okta, and Entra ID connections.